### PR TITLE
Rename ESLint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ reactjs18-3d-portfolio/
 ├   └── logo.svg
 ├── .env
 ├── .eslintignore
-├── .eslintrc.cjs
+├── eslint.config.js
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc.cjs

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,17 @@
-module.exports = {
+import { FlatCompat } from "@eslint/eslintrc";
+import js from "@eslint/js";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+const configArray = compat.config({
   root: true,
   env: { browser: true, es2020: true },
   extends: [
@@ -7,15 +20,9 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "eslint-config-prettier",
   ],
-  ignorePatterns: ["dist", ".eslintrc.cjs"],
+  ignorePatterns: ["dist", "eslint.config.js"],
   parser: "@typescript-eslint/parser",
   plugins: ["react-refresh"],
-  rules: {
-    "react-refresh/only-export-components": [
-      "warn",
-      { allowConstantExport: true },
-    ],
-  },
   settings: {
     react: {
       // Tells eslint-plugin-react to automatically detect the version of React to use.
@@ -31,7 +38,10 @@ module.exports = {
   },
   rules: {
     // Add your own rules here to override ones from the extended configs.
-    "@typescript-eslint/ban-ts-comment": ["off"],
-    "@typescript-eslint/no-explicit-any": ["off"],
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-explicit-any": "off",
   },
-};
+});
+configArray[1].files = ["**/*.ts", "**/*.tsx"];
+
+export default configArray;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- rename `.eslintrc.cjs` to `eslint.config.js`
- convert configuration to flat format
- update lint script and docs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841074322f08328a21833aa62d4a63c