### PR TITLE
Add sizing props to desktop windows

### DIFF
--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -40,27 +40,52 @@ const Desktop = () => {
         </Link>
       </div>
       {open.minesweeper && (
-        <Window title="Minesweeper" onClose={() => toggle("minesweeper")}> 
+        <Window
+          title="Minesweeper"
+          onClose={() => toggle("minesweeper")}
+          width="20rem"
+          height="20rem"
+        >
           <Minesweeper />
         </Window>
       )}
       {open.solitaire && (
-        <Window title="Solitaire" onClose={() => toggle("solitaire")}> 
+        <Window
+          title="Solitaire"
+          onClose={() => toggle("solitaire")}
+          width="40rem"
+          height="32rem"
+        >
           <Solitaire />
         </Window>
       )}
       {open.documents && (
-        <Window title="My Documents" onClose={() => toggle("documents")}> 
+        <Window
+          title="My Documents"
+          onClose={() => toggle("documents")}
+          width="20rem"
+          height="16rem"
+        >
           <Documents />
         </Window>
       )}
       {open.pictures && (
-        <Window title="My Pictures" onClose={() => toggle("pictures")}> 
+        <Window
+          title="My Pictures"
+          onClose={() => toggle("pictures")}
+          width="24rem"
+          height="20rem"
+        >
           <Pictures />
         </Window>
       )}
       {open.browser && (
-        <Window title="Browser" onClose={() => toggle("browser")}> 
+        <Window
+          title="Browser"
+          onClose={() => toggle("browser")}
+          width="28rem"
+          height="30rem"
+        >
           <WebBrowser />
         </Window>
       )}

--- a/src/components/desktop/Window.tsx
+++ b/src/components/desktop/Window.tsx
@@ -5,11 +5,13 @@ interface Props {
   title: string;
   onClose: () => void;
   children: ReactNode;
+  width?: number | string;
+  height?: number | string;
 }
 
 type State = "normal" | "minimized" | "maximized";
 
-const Window = ({ title, onClose, children }: Props) => {
+const Window = ({ title, onClose, children, width, height }: Props) => {
   const [state, setState] = useState<State>("normal");
 
   if (state === "minimized") {
@@ -30,8 +32,9 @@ const Window = ({ title, onClose, children }: Props) => {
     <Draggable handle=".window-title" disabled={state === "maximized"}>
       <div
         className={`absolute bg-gray-800 border border-gray-500 ${
-          state === "maximized" ? "inset-2" : "top-20 left-20 w-96"
+          state === "maximized" ? "inset-2" : "top-20 left-20"
         }`}
+        style={{ width, height, maxWidth: '80vw', maxHeight: '80vh' }}
       >
         <div className="window-title cursor-move bg-gray-700 px-2 py-1 flex justify-between items-center">
           <span>{title}</span>
@@ -47,7 +50,7 @@ const Window = ({ title, onClose, children }: Props) => {
             <button onClick={onClose}>X</button>
           </div>
         </div>
-        <div className="p-2 bg-gray-800 overflow-auto max-h-[32rem]">
+        <div className="p-2 bg-gray-800 overflow-auto h-full">
           {children}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add optional `width`/`height` props to `Window`
- cap windows at 80% of viewport via styles
- specify sizes for app windows when opened from the desktop

## Testing
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_6841074ddcb08328b917f5ad518bbc79