### PR TITLE
Add header styling and remove stars

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import {
   Navbar,
   Tech,
   Works,
-  StarsCanvas,
   Desktop,
 } from "./components";
 import { useEffect } from "react";
@@ -29,7 +28,6 @@ const App = () => {
           path="/"
           element={
             <div className="bg-primary relative z-0">
-              <StarsCanvas />
               <div className="bg-hero-pattern bg-cover bg-center bg-no-repeat">
                 <Navbar />
                 <Hero />

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -20,7 +20,6 @@ const ExperienceCard: React.FC<TExperience> = (experience) => {
         color: "#fff",
       }}
       contentArrowStyle={{ borderRight: "7px solid  #232631" }}
-      date={experience.date}
       iconStyle={{ background: experience.iconBg }}
       icon={
         <div className="flex h-full w-full items-center justify-center">
@@ -40,6 +39,7 @@ const ExperienceCard: React.FC<TExperience> = (experience) => {
         >
           {experience.companyName}
         </p>
+        <p className="text-white-100 text-[14px]">{experience.date}</p>
       </div>
 
       <ul className="ml-5 mt-5 list-disc space-y-2">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -29,8 +29,7 @@ const Hero = () => {
 
         <div>
           <h1 className={`${styles.heroHeadText} text-white`}>
-           {" "}
-            <span className="text-[#915EFF]">{config.hero.name}</span>
+            <span className="text-stroke text-[#915EFF]">{config.hero.name}</span>
           </h1>
           <p className={`${styles.heroSubText} text-white-100 mt-2`}>
             {config.hero.p[0]} <br className="hidden sm:block" />

--- a/src/components/sections/Tech.tsx
+++ b/src/components/sections/Tech.tsx
@@ -1,12 +1,14 @@
 import { BallCanvas } from "../canvas";
 import { SectionWrapper } from "../../hoc";
 import { technologies } from "../../constants";
+import { Header } from "../atoms/Header";
 
 const Tech = () => {
   // Only show the first 8 technologies
   const visibleTechnologies = technologies.slice(0, 8);
   return (
     <>
+      <Header useMotion={true} p="" h2="Technology Experience" />
       <div className="flex flex-row flex-wrap justify-center gap-10">
         {visibleTechnologies.map((technology) => (
           <div

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -4,12 +4,12 @@ export const styles = {
   padding: "sm:px-16 px-6 sm:py-16 py-10",
 
   heroHeadText:
-    "font-black text-white lg:text-[80px] sm:text-[60px] xs:text-[50px] text-[40px] lg:leading-[98px] mt-2",
+    "header-shadow font-black text-white lg:text-[80px] sm:text-[60px] xs:text-[50px] text-[40px] lg:leading-[98px] mt-2",
   heroSubText:
     "text-[#dfd9ff] font-medium lg:text-[30px] sm:text-[26px] xs:text-[20px] text-[16px] lg:leading-[40px]",
 
   sectionHeadText:
-    "text-white font-black md:text-[60px] sm:text-[50px] xs:text-[40px] text-[30px]",
+    "header-shadow text-white font-black md:text-[60px] sm:text-[50px] xs:text-[40px] text-[30px]",
   sectionSubText:
     "sm:text-[18px] text-[14px] text-secondary uppercase tracking-wider",
 };

--- a/src/globals.css
+++ b/src/globals.css
@@ -40,6 +40,16 @@ body, .bg-primary {
 .text-teal-light { color: var(--teal-light) !important; }
 .text-teal-mid { color: var(--teal-mid) !important; }
 
+/* Utility classes for text effects */
+.text-stroke {
+  -webkit-text-stroke: 1px #000000;
+  text-stroke: 1px #000000;
+}
+
+.header-shadow {
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
 .hash-span {
   margin-top: -100px;
   padding-bottom: 100px;


### PR DESCRIPTION
## Summary
- add utility classes for header shadows and text stroke
- give hero name outline
- show experience dates under company name
- add header to the tech section
- remove the star background

## Testing
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_684124e972508328be36acacc32e3d84