### PR TITLE
Add text shadows and remove planet from contact

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -73,17 +73,17 @@ const Navbar = () => {
             <li
               key={nav.id}
               className={`
-                cursor-pointer text-[20px] font-medium transition-colors
+                cursor-pointer text-[20px] font-medium transition-colors text-shadow
                 ${active === nav.id ? "text-teal-light" : "text-white"}
                 hover:text-teal-dark
               `}
               onClick={() => setActive(nav.id)}
             >
-              <a href={`#${nav.id}`}>{nav.title}</a>
+              <a href={`#${nav.id}`} className="text-shadow">{nav.title}</a>
             </li>
           ))}
-          <li className="cursor-pointer text-[20px] font-medium text-white hover:text-teal-dark">
-            <Link to="/desktop">Desktop</Link>
+          <li className="cursor-pointer text-[20px] font-medium text-white hover:text-teal-dark text-shadow">
+            <Link to="/desktop" className="text-shadow">Desktop</Link>
           </li>
         </ul>
       </div>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef } from "react";
 import { motion } from "framer-motion";
 import emailjs from "@emailjs/browser";
 
-import { EarthCanvas } from "../canvas";
 import { SectionWrapper } from "../../hoc";
 import { slideIn } from "../../utils/motion";
 import { config } from "../../constants/config";
@@ -110,12 +109,6 @@ const Contact = () => {
         </form>
       </motion.div>
 
-      <motion.div
-        variants={slideIn("right", "tween", 0.2, 1)}
-        className="h-[350px] md:h-[550px] xl:h-auto xl:flex-1"
-      >
-        <EarthCanvas />
-      </motion.div>
     </div>
   );
 };

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -32,7 +32,7 @@ const Hero = () => {
            {" "}
             <span className="text-[#915EFF]">{config.hero.name}</span>
           </h1>
-          <p className={`${styles.heroSubText} text-white-100 mt-2`}>
+          <p className={`${styles.heroSubText} text-white-100 mt-2 text-shadow`}>
             {config.hero.p[0]} <br className="hidden sm:block" />
             {config.hero.p[1]}
           </p>

--- a/src/globals.css
+++ b/src/globals.css
@@ -239,3 +239,7 @@ body, .bg-primary {
         -1.8em -1.8em 0 0em #ffffff;
     }
   }
+
+.text-shadow {
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
## Summary
- remove Earth canvas from Contact section
- add generic `.text-shadow` utility class
- apply shadow class to navbar links and hero tagline

## Testing
- `npm run lint`
- `npm run ts:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684142247d1c8328be550ac660912305