### PR TITLE
Implement interactive desktop mockup

### DIFF
--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -7,6 +7,19 @@ import Pictures from "./Pictures";
 import WebBrowser from "./WebBrowser";
 import { Link } from "react-router-dom";
 
+const loginScreen = new URL("../../assets/mockups/desktop screens/desktop-userlogin.png", import.meta.url).href;
+const iconPC = new URL("../../assets/mockups/desktop icons/icon-thispc.PNG", import.meta.url).href;
+const iconDocs = new URL("../../assets/mockups/desktop icons/icon-documents.PNG", import.meta.url).href;
+const iconPics = new URL("../../assets/mockups/desktop icons/icon-pictures.PNG", import.meta.url).href;
+const corkboard = new URL("../../assets/mockups/corkboard.png", import.meta.url).href;
+const iconVideos = new URL("../../assets/mockups/desktop icons/icon-videos.PNG", import.meta.url).href;
+const iconSolitaire = new URL("../../assets/mockups/desktop icons/icon-solitaire.png", import.meta.url).href;
+const iconMines = new URL("../../assets/mockups/desktop icons/icon-minesweeper.png", import.meta.url).href;
+const iconContacts = new URL("../../assets/mockups/desktop icons/icon-contacts.PNG", import.meta.url).href;
+const iconRecycle = new URL("../../assets/mockups/desktop icons/icon-recyclebin.png", import.meta.url).href;
+const pinBlue = new URL("../../assets/pushpin/pushpin-blue.png", import.meta.url).href;
+const pinRed = new URL("../../assets/pushpin/pushpin-red.png", import.meta.url).href;
+
 interface AppState {
   minesweeper: boolean;
   solitaire: boolean;
@@ -24,70 +37,104 @@ const Desktop = () => {
     browser: false,
   });
 
+  const [stage, setStage] = useState<'login' | 'desktop'>('login');
+
   const toggle = (key: keyof AppState) =>
     setOpen((o) => ({ ...o, [key]: !o[key] }));
 
+  const icons = [
+    { name: "This PC", img: iconPC, onClick: () => toggle("documents") },
+    { name: "Documents", img: iconDocs, onClick: () => toggle("documents") },
+    { name: "Pictures", img: iconPics, onClick: () => toggle("pictures") },
+    { name: "Videos", img: iconVideos, onClick: () => toggle("browser") },
+    { name: "Solitaire", img: iconSolitaire, onClick: () => toggle("solitaire") },
+    { name: "Minesweeper", img: iconMines, onClick: () => toggle("minesweeper") },
+    { name: "Contacts", img: iconContacts, onClick: () => toggle("browser") },
+    { name: "Recycle Bin", img: iconRecycle, onClick: () => {} },
+  ];
+
   return (
-    <div className="relative h-screen w-screen bg-blue-900 text-white select-none">
-      <div className="p-4 space-x-4">
-        <button onClick={() => toggle("minesweeper")}>Minesweeper</button>
-        <button onClick={() => toggle("solitaire")}>Solitaire</button>
-        <button onClick={() => toggle("documents")}>My Documents</button>
-        <button onClick={() => toggle("pictures")}>My Pictures</button>
-        <button onClick={() => toggle("browser")}>Browser</button>
-        <Link to="/" className="ml-4 underline">
-          Back to site
-        </Link>
-      </div>
-      {open.minesweeper && (
-        <Window
-          title="Minesweeper"
-          onClose={() => toggle("minesweeper")}
-          width="20rem"
-          height="20rem"
-        >
-          <Minesweeper />
-        </Window>
+    <div className="relative h-screen w-screen text-white select-none">
+      {stage === 'login' && (
+        <img
+          src={loginScreen}
+          alt="login"
+          className="absolute inset-0 h-full w-full object-cover cursor-pointer"
+          onClick={() => setStage('desktop')}
+        />
       )}
-      {open.solitaire && (
-        <Window
-          title="Solitaire"
-          onClose={() => toggle("solitaire")}
-          width="40rem"
-          height="32rem"
-        >
-          <Solitaire />
-        </Window>
-      )}
-      {open.documents && (
-        <Window
-          title="My Documents"
-          onClose={() => toggle("documents")}
-          width="20rem"
-          height="16rem"
-        >
-          <Documents />
-        </Window>
-      )}
-      {open.pictures && (
-        <Window
-          title="My Pictures"
-          onClose={() => toggle("pictures")}
-          width="24rem"
-          height="20rem"
-        >
-          <Pictures />
-        </Window>
-      )}
-      {open.browser && (
-        <Window
-          title="Browser"
-          onClose={() => toggle("browser")}
-          width="28rem"
-          height="30rem"
-        >
-          <WebBrowser />
-        </Window>
+      {stage === 'desktop' && (
+        <>
+          <img
+            src={corkboard}
+            alt="wallpaper"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <img src={pinBlue} className="absolute left-2 top-2 w-6" />
+          <img src={pinRed} className="absolute right-2 bottom-2 w-6" />
+          <div className="absolute inset-0 grid grid-cols-4 gap-4 p-4 text-xs pointer-events-auto">
+            {icons.map((ic) => (
+              <button key={ic.name} onClick={ic.onClick} className="flex flex-col items-center hover:opacity-80">
+                <img src={ic.img} alt={ic.name} className="h-12 w-12" />
+                <span>{ic.name}</span>
+              </button>
+            ))}
+            <Link to="/" className="flex flex-col items-center hover:opacity-80">
+              <img src={iconPC} alt="Back" className="h-12 w-12" />
+              <span>Back</span>
+            </Link>
+          </div>
+          {open.minesweeper && (
+            <Window
+              title="Minesweeper"
+              onClose={() => toggle("minesweeper")}
+              width="20rem"
+              height="20rem"
+            >
+              <Minesweeper />
+            </Window>
+          )}
+          {open.solitaire && (
+            <Window
+              title="Solitaire"
+              onClose={() => toggle("solitaire")}
+              width="40rem"
+              height="32rem"
+            >
+              <Solitaire />
+            </Window>
+          )}
+          {open.documents && (
+            <Window
+              title="My Documents"
+              onClose={() => toggle("documents")}
+              width="20rem"
+              height="16rem"
+            >
+              <Documents />
+            </Window>
+          )}
+          {open.pictures && (
+            <Window
+              title="My Pictures"
+              onClose={() => toggle("pictures")}
+              width="24rem"
+              height="20rem"
+            >
+              <Pictures />
+            </Window>
+          )}
+          {open.browser && (
+            <Window
+              title="Browser"
+              onClose={() => toggle("browser")}
+              width="28rem"
+              height="30rem"
+            >
+              <WebBrowser />
+            </Window>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   EarthCanvas,
   BallCanvas,

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,24 +1,83 @@
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 
 import { styles } from "../../constants/styles";
 import { config } from "../../constants/config";
 
+import stickyC from "../../assets/sticky/sticky-c.png";
+import stickyL from "../../assets/sticky/sticky-li.png";
+import stickyI from "../../assets/sticky/sticky-li.png";
+import stickyC2 from "../../assets/sticky/sticky-c2.png";
+import stickyK from "../../assets/sticky/sticky-k.png";
+import stickyH from "../../assets/sticky/sticky-h.png";
+import stickyE from "../../assets/sticky/sticky-e.png";
+import stickyR from "../../assets/sticky/sticky-re.png";
 
+const notes = [stickyC, stickyL, stickyI, stickyC2, stickyK, stickyH, stickyE, stickyR, stickyE];
+const positions = [
+  { left: "30%", top: "35%" },
+  { left: "38%", top: "32%" },
+  { left: "46%", top: "34%" },
+  { left: "54%", top: "35%" },
+  { left: "62%", top: "32%" },
+  { left: "37%", top: "50%" },
+  { left: "45%", top: "52%" },
+  { left: "53%", top: "51%" },
+  { left: "61%", top: "52%" },
+];
 
 const Hero = () => {
   const navigate = useNavigate();
+  const [visible, setVisible] = useState(0);
+  const [removed, setRemoved] = useState<boolean[]>(() => Array(notes.length).fill(false));
+
+  useEffect(() => {
+    const timers = notes.map((_, i) =>
+      setTimeout(() => setVisible((v) => Math.max(v, i + 1)), (i + 1) * 300)
+    );
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (removed.every((r, i) => r || i >= visible)) return;
+    if (removed.every(Boolean) && visible >= notes.length) {
+      setTimeout(() => navigate("/desktop"), 300);
+    }
+  }, [removed, visible, navigate]);
+
+  const removeNote = (idx: number) =>
+    setRemoved((arr) => {
+      const na = [...arr];
+      na[idx] = true;
+      return na;
+    });
+
   return (
-    <section className={`relative mx-auto h-screen w-full`}>
+    <section className="relative mx-auto h-screen w-full">
       {/* Hero background monitor image (clickable) */}
       <div
-        className="absolute inset-0 -z-10 cursor-pointer select-none"
-        style={{
-          background: `url('/herobg.png') center/cover no-repeat`,
-        }}
-        onClick={() => navigate('/desktop')}
-        title="Click to open desktop"
-      />
+        className="absolute inset-0 -z-10 select-none"
+        style={{ background: `url('/herobg.png') center/cover no-repeat` }}
+        title="Click the notes"
+      >
+        {notes.slice(0, visible).map((src, i) =>
+          removed[i] ? null : (
+            <motion.img
+              key={i}
+              src={src}
+              alt="note"
+              className="absolute w-24 cursor-pointer"
+              style={positions[i]}
+              initial={{ opacity: 0, rotate: -15 }}
+              animate={{ opacity: 1, rotate: 0 }}
+              onClick={() => removeNote(i)}
+            />
+          )
+        )}
+      </div>
       <div
         className={`absolute inset-0 top-[120px] mx-auto max-w-7xl ${styles.paddingX} flex flex-row items-start gap-5`}
       >
@@ -42,11 +101,7 @@ const Hero = () => {
           <div className="border-secondary flex h-[64px] w-[35px] items-start justify-center rounded-3xl border-4 p-2">
             <motion.div
               animate={{ y: [0, 24, 0] }}
-              transition={{
-                duration: 1.5,
-                repeat: Infinity,
-                repeatType: "loop",
-              }}
+              transition={{ duration: 1.5, repeat: Infinity, repeatType: 'loop' }}
               className="bg-secondary mb-1 h-3 w-3 rounded-full"
             />
           </div>


### PR DESCRIPTION
## Summary
- animate sticky notes on hero background
- add login screen and wallpaper icons for desktop mock-up
- refine desktop and hero interactions

## Testing
- `npm run lint`
- `npm run ts:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684638b6b5d0832882c592df99d99476