### PR TITLE
Fix PNG type declaration for TypeScript build

### DIFF
--- a/src/assets/rochellecartoon.PNG.d.ts
+++ b/src/assets/rochellecartoon.PNG.d.ts
@@ -1,4 +1,2 @@
-declare module "*.PNG" {
-  const value: string;
-  export default value;
-}
+declare const src: string;
+export default src;


### PR DESCRIPTION
## Summary
- adjust rochellecartoon.PNG.d.ts to export a default value

## Testing
- `npm run ts:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846ad9f0ad083288957f04e6e8c9d3e